### PR TITLE
Update codebase for ROS2 Jazzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,20 @@ This repository implements the ROS2 version of VINS-MONO, mainly including the f
 ![mh01](https://github.com/dongbo19/VINS-MONO-ROS2/blob/main/config_pkg/config/gif/vins_ros2_mh01.gif)
 ![mh02](https://github.com/dongbo19/VINS-MONO-ROS2/blob/main/config_pkg/config/gif/vins_ros2_mh02.gif)
 # 2. Prerequisites
-* System  
-  * Ubuntu 20.04  
-  * ROS2 foxy
+* System
+  * Ubuntu 24.04
+  * ROS2 jazzy
 * Libraries
-  * OpenCV 4.2.0
-  * [Ceres Solver](http://ceres-solver.org/installation.html) 1.14.0
+  * OpenCV 4.2 or newer
+  * [Ceres Solver](http://ceres-solver.org/installation.html) 2.2 or newer
   * Eigen 3.3.7
 # 3. Build VINS-MONO-ROS2
-Clone the repository and colcon build:  
+Clone the repository and colcon build:
 ```
 cd $(PATH_TO_YOUR_ROS2_WS)/src
 git clone https://github.com/dongbo19/VINS-MONO-ROS2.git
 cd ..
+sudo apt install libceres-dev libopencv-dev
 colcon build
 ```
 # 4. VINS-MONO-ROS2 on EuRoC datasets

--- a/ar_demo/CMakeLists.txt
+++ b/ar_demo/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(ar_demo)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-Wextra -Wpedantic)
 
 find_package(ament_cmake REQUIRED)

--- a/benchmark_publisher/CMakeLists.txt
+++ b/benchmark_publisher/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(benchmark_publisher)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-Wextra -Wpedantic)
 
 find_package(ament_cmake REQUIRED)

--- a/camera_model/CMakeLists.txt
+++ b/camera_model/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(camera_model)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-Wextra -Wpedantic)
 
 find_package(ament_cmake REQUIRED)

--- a/camera_model/include/camodocal/gpl/EigenQuaternionParameterization.h
+++ b/camera_model/include/camodocal/gpl/EigenQuaternionParameterization.h
@@ -1,7 +1,12 @@
 #ifndef EIGENQUATERNIONPARAMETERIZATION_H
 #define EIGENQUATERNIONPARAMETERIZATION_H
 
-#include "ceres/local_parameterization.h"
+#include <ceres/version.h>
+#if CERES_VERSION_MAJOR >= 2
+#include <ceres/manifold.h>
+#else
+#include <ceres/local_parameterization.h>
+#endif
 
 namespace camodocal
 {

--- a/config_pkg/CMakeLists.txt
+++ b/config_pkg/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(config_pkg)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-Wextra -Wpedantic)
 
 find_package(ament_cmake REQUIRED)

--- a/feature_tracker/CMakeLists.txt
+++ b/feature_tracker/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(feature_tracker)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-Wextra -Wpedantic)
 set(CMAKE_BUILD_TYPE Release)
 

--- a/feature_tracker/src/feature_tracker_node.cpp
+++ b/feature_tracker/src/feature_tracker_node.cpp
@@ -180,7 +180,7 @@ void img_callback(const sensor_msgs::msg::Image::SharedPtr img_msg)
             for (int i = 0; i < NUM_OF_CAM; i++)
             {
                 cv::Mat tmp_img = stereo_img.rowRange(i * ROW, (i + 1) * ROW);
-                cv::cvtColor(show_img, tmp_img, CV_GRAY2RGB);
+                cv::cvtColor(show_img, tmp_img, cv::COLOR_GRAY2RGB);
 
                 for (unsigned int j = 0; j < trackerData[i].cur_pts.size(); j++)
                 {

--- a/pose_graph/CMakeLists.txt
+++ b/pose_graph/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(pose_graph)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-Wextra -Wpedantic)
 
 find_package(ament_cmake REQUIRED)

--- a/pose_graph/src/keyframe.cpp
+++ b/pose_graph/src/keyframe.cpp
@@ -278,7 +278,7 @@ bool KeyFrame::findConnection(KeyFrame* old_kf)
 	        cv::Mat gray_img, loop_match_img;
 	        cv::Mat old_img = old_kf->image;
 	        cv::hconcat(image, old_img, gray_img);
-	        cvtColor(gray_img, loop_match_img, CV_GRAY2RGB);
+	        cvtColor(gray_img, loop_match_img, cv::COLOR_GRAY2RGB);
 	        for(int i = 0; i< (int)point_2d_uv.size(); i++)
 	        {
 	            cv::Point2f cur_pt = point_2d_uv[i];
@@ -316,7 +316,7 @@ bool KeyFrame::findConnection(KeyFrame* old_kf)
             cv::Mat old_img = old_kf->image;
             cv::hconcat(image, gap_image, gap_image);
             cv::hconcat(gap_image, old_img, gray_img);
-            cvtColor(gray_img, loop_match_img, CV_GRAY2RGB);
+            cvtColor(gray_img, loop_match_img, cv::COLOR_GRAY2RGB);
 	        for(int i = 0; i< (int)matched_2d_cur.size(); i++)
 	        {
 	            cv::Point2f cur_pt = matched_2d_cur[i];
@@ -372,7 +372,7 @@ bool KeyFrame::findConnection(KeyFrame* old_kf)
             cv::Mat old_img = old_kf->image;
             cv::hconcat(image, gap_image, gap_image);
             cv::hconcat(gap_image, old_img, gray_img);
-            cvtColor(gray_img, loop_match_img, CV_GRAY2RGB);
+            cvtColor(gray_img, loop_match_img, cv::COLOR_GRAY2RGB);
 	        for(int i = 0; i< (int)matched_2d_cur.size(); i++)
 	        {
 	            cv::Point2f cur_pt = matched_2d_cur[i];
@@ -422,7 +422,7 @@ bool KeyFrame::findConnection(KeyFrame* old_kf)
 	            cv::Mat old_img = old_kf->image;
 	            cv::hconcat(image, gap_image, gap_image);
 	            cv::hconcat(gap_image, old_img, gray_img);
-	            cvtColor(gray_img, loop_match_img, CV_GRAY2RGB);
+	            cvtColor(gray_img, loop_match_img, cv::COLOR_GRAY2RGB);
 	            for(int i = 0; i< (int)matched_2d_cur.size(); i++)
 	            {
 	                cv::Point2f cur_pt = matched_2d_cur[i];

--- a/vins_estimator/CMakeLists.txt
+++ b/vins_estimator/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(vins_estimator)
 
 set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-Wextra -Wpedantic)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
## Summary
- bump C++ standard to 17 across packages
- replace deprecated OpenCV constant with COLOR_GRAY2RGB

## Testing
- `colcon build --packages-select ar_demo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686417b687fc8326a65f3d76fb3927fa